### PR TITLE
Use html webpack plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # debuginfo
 /npm-debug.log
 /yarn-error.log
+
+# misc
+.history

--- a/config/webpack/base.config.js
+++ b/config/webpack/base.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
   context: path.resolve(__dirname, "../../src"),
@@ -45,5 +46,8 @@ module.exports = {
         ]
       }
     ]
-  }
+  },
+  plugins: [
+    new HtmlWebpackPlugin()
+  ]
 };


### PR DESCRIPTION
**Summary**:
- add `.history` dir to `.gitignore`
- use existing dependency `html-webpack-plugin` in webpack config
- static html page that uses `index.js` will no be generated on `yarn start`