### PR TITLE
Remove the License heading from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ This setup comes with the follwing features:
 - ES6 Support via [babeljs](https://babeljs.io/)
 - An EditorConfig setup
 
-## License / Usage
+## Usage
 Feel free to fork this repo and modify it according to your needs. Leave me a note if you like this setup.


### PR DESCRIPTION
There's no need for it. Also, a separate LICENSE file is available so no need of its mention here